### PR TITLE
Update gen loop mom canon map

### DIFF
--- a/src/Canon.jl
+++ b/src/Canon.jl
@@ -61,6 +61,7 @@ function gen_loop_mom_canon_map(
 )::Dict{Basic,Basic}
 #########################################################
 
+  ### should be moved to AmpTools.jl
   function is_sym_index_format(input::Basic, sym::Union{Basic, String})::Bool
     if SymEngine.get_symengine_class(input) != :Symbol
       return false
@@ -118,6 +119,7 @@ function gen_loop_mom_canon_map(
     sort!(k_list; by=get_ext_index)
     return k_list
   end
+  ### should be moved to AmpTools.jl
 
   function gen_repl_rule_sort_index(mom_list::Vector{Basic})::Vector{Basic}
     local tmp_mom_list = unique( abs, mom_list )


### PR DESCRIPTION
It seems all done:
- [x] We can transform the configuration for given diagram into the first one as much as possible.
- [x] We can ordering [q1,q2,q3] by their associated external momentum. For example, in two-loop case, we can require [q1+k2, q2+k1] be transformed into [q2+k2,q1+k1] by simply renaming.
